### PR TITLE
Update desktop UI for stack/component operations

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -4,23 +4,33 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/cloudposse/atmos/internal/exec"
 	"github.com/cloudposse/atmos/pkg/config"
 	"github.com/cloudposse/atmos/pkg/list"
 	"github.com/cloudposse/atmos/pkg/schema"
+	u "github.com/cloudposse/atmos/pkg/utils"
 	"github.com/wailsapp/wails/v2/pkg/runtime"
+	"gopkg.in/yaml.v3"
 )
 
 // App struct
 type App struct {
-	ctx context.Context
+	ctx        context.Context
+	configPath string
 }
 
 // NewApp creates a new App application struct
 func NewApp() *App {
 	return &App{}
+}
+
+// StackComponent represents a Terraform component in a stack.
+type StackComponent struct {
+	Stack     string `json:"stack"`
+	Component string `json:"component"`
 }
 
 // startup is called when the app starts. The context is saved
@@ -60,4 +70,62 @@ func (a *App) Greet(atmosPath string) string {
 		return "Error filtering stacks: " + err.Error()
 	}
 	return fmt.Sprintf("Hello %s, It's show time!", strings.Join(output, "\n"))
+}
+
+// LoadAtmosData loads stacks and components from the provided atmos.yaml path.
+func (a *App) LoadAtmosData(atmosPath string) ([]StackComponent, error) {
+	a.configPath = atmosPath
+
+	configAndStacksInfo := schema.ConfigAndStacksInfo{}
+	configAndStacksInfo.AtmosBasePath = filepath.Dir(atmosPath)
+	atmosConfig, err := config.InitCliConfig(configAndStacksInfo, true)
+	if err != nil {
+		return nil, err
+	}
+	stacksMap, err := exec.ExecuteDescribeStacks(atmosConfig, "", nil, nil, nil, false, false, false, false, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var result []StackComponent
+	for stackName := range stacksMap {
+		components, err := list.FilterAndListComponents(stackName, stacksMap)
+		if err != nil {
+			continue
+		}
+		for _, comp := range components {
+			result = append(result, StackComponent{Stack: stackName, Component: comp})
+		}
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Stack == result[j].Stack {
+			return result[i].Component < result[j].Component
+		}
+		return result[i].Stack < result[j].Stack
+	})
+	return result, nil
+}
+
+// Describe returns the YAML description of the provided stack/component.
+func (a *App) Describe(stack, component string) string {
+	data, err := exec.ExecuteDescribeComponent(component, stack, true, true, nil)
+	if err != nil {
+		return "Error: " + err.Error()
+	}
+	b, err := yaml.Marshal(data)
+	if err != nil {
+		return "Error: " + err.Error()
+	}
+	return string(b)
+}
+
+// RunTerraform executes a terraform command and returns its output.
+func (a *App) RunTerraform(cmd, stack, component string) string {
+	command := fmt.Sprintf("atmos terraform %s %s -s %s", cmd, component, stack)
+	out, err := u.ExecuteShellAndReturnOutput(command, "terraform-"+cmd, filepath.Dir(a.configPath), nil, false)
+	if err != nil {
+		return "Error: " + err.Error()
+	}
+	return out
 }

--- a/desktop/frontend/src/App.css
+++ b/desktop/frontend/src/App.css
@@ -3,6 +3,40 @@
     text-align: center;
 }
 
+.top-bar {
+    margin: 10px;
+}
+
+.main {
+    display: flex;
+    height: calc(100% - 80px);
+}
+
+.left {
+    width: 100px;
+    padding: 10px;
+}
+
+.center {
+    flex: 1;
+    padding: 10px;
+}
+
+.right {
+    width: 40%;
+    padding: 10px;
+    overflow: auto;
+    background-color: #f5f5f5;
+}
+
+.items {
+    width: 100%;
+    border-collapse: collapse;
+}
+.items tr.selected {
+    background-color: #e0e0e0;
+}
+
 #logo {
     display: block;
     width: 50%;

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1,27 +1,87 @@
-import {useState} from 'react';
-import logo from './assets/images/logo-universal.png';
-import './App.css';
-import {Greet, PickConfigFile} from "../wailsjs/go/main/App";
+import { useState } from 'react'
+import logo from './assets/images/logo-universal.png'
+import './App.css'
+import {
+    PickConfigFile,
+    LoadAtmosData,
+    Describe,
+    RunTerraform
+} from "../wailsjs/go/main/App"
+
+interface Item {stack: string, component: string}
 
 function App() {
-    const [resultText, setResultText] = useState("");
-    const [configPath, setConfigPath] = useState('');
-    const updateResultText = (result: string) => setResultText(result);
+    const [configPath, setConfigPath] = useState('')
+    const [items, setItems] = useState<Item[]>([])
+    const [filterStack, setFilterStack] = useState('')
+    const [filterComponent, setFilterComponent] = useState('')
+    const [selected, setSelected] = useState<Item | null>(null)
+    const [describeText, setDescribeText] = useState('')
+    const [command, setCommand] = useState('plan')
+    const [consoleOut, setConsoleOut] = useState('')
 
     function chooseConfig() {
         PickConfigFile().then((path: string) => {
             if (path) {
-                setConfigPath(path);
-                Greet(path).then(updateResultText);
+                setConfigPath(path)
+                LoadAtmosData(path).then(setItems)
             }
-        });
+        })
     }
+
+    function selectRow(item: Item) {
+        setSelected(item)
+        Describe(item.stack, item.component).then(setDescribeText)
+    }
+
+    function startCommand() {
+        if (!selected) return
+        RunTerraform(command, selected.stack, selected.component).then(setConsoleOut)
+    }
+
+    const filtered = items.filter(i =>
+        (filterStack === '' || i.stack.includes(filterStack)) &&
+        (filterComponent === '' || i.component.includes(filterComponent))
+    )
 
     return (
         <div id="App">
-            <img src={logo} id="logo" alt="logo"/>
-            <button className="btn" onClick={chooseConfig}>Select atmos.yaml</button>
-            <div id="result" className="result console">{resultText}</div>
+            <div className="top-bar">
+                <input value={configPath} readOnly placeholder="Select atmos.yaml"/>
+                <button className="btn" onClick={chooseConfig}>Select atmos.yaml</button>
+            </div>
+            <div className="main">
+                <div className="left">
+                    <select value={command} onChange={e => setCommand(e.target.value)}>
+                        <option value="plan">plan</option>
+                        <option value="apply">apply</option>
+                    </select>
+                </div>
+                <div className="center">
+                    <div className="filters">
+                        <input placeholder="Filter stack" value={filterStack} onChange={e => setFilterStack(e.target.value)}/>
+                        <input placeholder="Filter component" value={filterComponent} onChange={e => setFilterComponent(e.target.value)}/>
+                    </div>
+                    <table className="items">
+                        <thead>
+                        <tr><th>Stack</th><th>Component</th></tr>
+                        </thead>
+                        <tbody>
+                        {filtered.map((it, idx) => (
+                            <tr key={idx} onClick={() => selectRow(it)} className={selected===it?"selected":""}>
+                                <td>{it.stack}</td>
+                                <td>{it.component}</td>
+                            </tr>
+                        ))}
+                        </tbody>
+                    </table>
+                    <button className="btn" onClick={startCommand}>Start</button>
+                    <pre className="console">{consoleOut}</pre>
+                </div>
+                <div className="right">
+                    <pre>{describeText}</pre>
+                </div>
+            </div>
         </div>
     )
 }

--- a/desktop/frontend/wailsjs/go/main/App.d.ts
+++ b/desktop/frontend/wailsjs/go/main/App.d.ts
@@ -4,3 +4,9 @@
 export function Greet(arg1:string):Promise<string>;
 
 export function PickConfigFile():Promise<string>;
+
+export function LoadAtmosData(arg1:string):Promise<Array<{stack:string,component:string}>>;
+
+export function Describe(arg1:string,arg2:string):Promise<string>;
+
+export function RunTerraform(arg1:string,arg2:string,arg3:string):Promise<string>;

--- a/desktop/frontend/wailsjs/go/main/App.js
+++ b/desktop/frontend/wailsjs/go/main/App.js
@@ -9,3 +9,15 @@ export function Greet(arg1) {
 export function PickConfigFile() {
   return window['go']['main']['App']['PickConfigFile']();
 }
+
+export function LoadAtmosData(arg1) {
+  return window['go']['main']['App']['LoadAtmosData'](arg1);
+}
+
+export function Describe(arg1, arg2) {
+  return window['go']['main']['App']['Describe'](arg1, arg2);
+}
+
+export function RunTerraform(arg1, arg2, arg3) {
+  return window['go']['main']['App']['RunTerraform'](arg1, arg2, arg3);
+}


### PR DESCRIPTION
## Summary
- add ability for frontend to load `atmos.yaml` and show stacks/components
- show describe output and run terraform plan/apply

## Testing
- `make lint` *(fails: Get "https://proxy.golang.org/...": Forbidden)*
- `make testacc-cover` *(fails: Get "https://proxy.golang.org/...": Forbidden)*
- `go test ./...` *(fails: Get "https://proxy.golang.org/...": Forbidden)*

------
https://chatgpt.com/codex/tasks/task_b_6862dd0c5438832bb0ee93e616b38a05