### PR TITLE
Add workspace tabs to desktop app

### DIFF
--- a/desktop/app.go
+++ b/desktop/app.go
@@ -8,6 +8,9 @@ import (
 	"sort"
 	"strings"
 
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+
 	"github.com/cloudposse/atmos/internal/exec"
 	"github.com/cloudposse/atmos/pkg/config"
 	"github.com/cloudposse/atmos/pkg/list"
@@ -141,4 +144,19 @@ func (a *App) RunTerraform(cmd, stack, component string) string {
 		return "Error: " + err.Error()
 	}
 	return out
+}
+
+// AuthenticateAWS tests AWS credentials for the provided profile.
+func (a *App) AuthenticateAWS(profile string) string {
+	ctx := context.Background()
+	cfg, err := awsconfig.LoadDefaultConfig(ctx, awsconfig.WithSharedConfigProfile(profile))
+	if err != nil {
+		return "Error: " + err.Error()
+	}
+	client := sts.NewFromConfig(cfg)
+	out, err := client.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		return "Error: " + err.Error()
+	}
+	return fmt.Sprintf("Authenticated as %s", *out.Arn)
 }

--- a/desktop/frontend/src/App.tsx
+++ b/desktop/frontend/src/App.tsx
@@ -1,214 +1,33 @@
 import { useState } from 'react'
-import YAML from 'js-yaml'
+import Workspace from './Workspace'
 
-import {
-    PickConfigFile,
-    LoadAtmosData,
-    Describe,
-    RunTerraform,
-} from "../wailsjs/go/main/App"
-
-interface Item { stack: string; component: string }
+interface WorkspaceInfo { id: number }
 
 function App() {
-    const [configPath, setConfigPath] = useState('')
-    const [items, setItems] = useState<Item[]>([])
-    const [filterStack, setFilterStack] = useState('')
-    const [filterComponent, setFilterComponent] = useState('')
-    const [selectedStack, setSelectedStack] = useState<string | null>(null)
-    const [selectedComponent, setSelectedComponent] = useState<string | null>(null)
-    const [describeText, setDescribeText] = useState('')
-    const [describeObj, setDescribeObj] = useState<any>(null)
-    const [sections, setSections] = useState<string[]>([])
-    const [sectionFilter, setSectionFilter] = useState('all')
-    const [command, setCommand] = useState('plan')
-    const [consoleOut, setConsoleOut] = useState('')
-    const [rightPanelCollapsed, setRightPanelCollapsed] = useState(false)
+    const [workspaces, setWorkspaces] = useState<WorkspaceInfo[]>([{ id: 0 }])
+    const [active, setActive] = useState(0)
 
-    function chooseConfig() {
-        PickConfigFile().then((path: string) => {
-            if (path) {
-                setConfigPath(path)
-                LoadAtmosData(path).then(setItems)
-            }
-        })
-    }
-
-    function selectStack(stack: string) {
-        setSelectedStack(stack)
-        setSelectedComponent(null)
-        setDescribeText('')
-        setDescribeObj(null)
-        setSections([])
-        setSectionFilter('all')
-    }
-
-    function selectComponent(component: string) {
-        if (!selectedStack) return
-        setSelectedComponent(component)
-        Describe(selectedStack, component).then(text => {
-            setDescribeText(text)
-            try {
-                const obj = YAML.load(text)
-                if (obj && typeof obj === 'object') {
-                    setDescribeObj(obj)
-                    setSections(Object.keys(obj as any))
-                } else {
-                    setDescribeObj(null)
-                    setSections([])
-                }
-            } catch {
-                setDescribeObj(null)
-                setSections([])
-            }
-            setSectionFilter('all')
-        })
-    }
-
-    function startCommand() {
-        if (!selectedStack || !selectedComponent) return
-        RunTerraform(command, selectedStack, selectedComponent).then(setConsoleOut)
-    }
-
-    const stacks = Array.from(new Set(items.map(i => i.stack)))
-        .filter(s => filterStack === '' || s.includes(filterStack))
-        .sort()
-
-    const components = selectedStack
-        ? Array.from(new Set(items.filter(i => i.stack === selectedStack).map(i => i.component)))
-            .filter(c => filterComponent === '' || c.includes(filterComponent))
-            .sort()
-        : []
-
-    let displayText = describeText
-    if (sectionFilter !== 'all' && describeObj) {
-        const part = (describeObj as any)[sectionFilter]
-        if (part !== undefined) {
-            displayText = YAML.dump(part)
-        }
+    function addWorkspace() {
+        const id = Date.now()
+        setWorkspaces([...workspaces, { id }])
+        setActive(workspaces.length)
     }
 
     return (
-        <div className="app-container">
-            <div className="header">
-                <input 
-                    className="header-input" 
-                    value={configPath} 
-                    readOnly 
-                    placeholder="Select atmos.yaml"
-                />
-                <button 
-                    className="header-button" 
-                    onClick={chooseConfig}
-                >
-                    Select atmos.yaml
-                </button>
+        <div className="workspaces-container">
+            <div className="tabs">
+                {workspaces.map((ws, idx) => (
+                    <div
+                        key={ws.id}
+                        className={`tab ${idx === active ? 'active' : ''}`}
+                        onClick={() => setActive(idx)}
+                    >
+                        Workspace {idx + 1}
+                    </div>
+                ))}
+                <div className="tab add" onClick={addWorkspace}>+</div>
             </div>
-            <div className="main-content">
-                <div className="sidebar">
-                    <select 
-                        className="sidebar-select hover:nav-gradient" 
-                        value={command} 
-                        onChange={e => setCommand(e.target.value)}
-                    >
-                        <option value="plan">plan</option>
-                        <option value="apply">apply</option>
-                    </select>
-                    <button
-                        className="sidebar-button"
-                        onClick={startCommand}
-                        disabled={!selectedStack || !selectedComponent}
-                    >
-                        Start
-                    </button>
-                </div>
-                <div className="content">
-                    <div className="filter-container">
-                        <input 
-                            className="filter-input" 
-                            placeholder="Filter stack" 
-                            value={filterStack} 
-                            onChange={e => setFilterStack(e.target.value)}
-                        />
-                        <input 
-                            className="filter-input" 
-                            placeholder="Filter component" 
-                            value={filterComponent} 
-                            onChange={e => setFilterComponent(e.target.value)}
-                        />
-                    </div>
-                    <div className="grid-container">
-                        <div className="list">
-                            <div className="list-title">
-                                <span>Stacks</span>
-                                <span>{stacks.length}</span>
-                            </div>
-                            <div className="list-content">
-                                {stacks.map(s => (
-                                    <div 
-                                        key={s} 
-                                        onClick={() => selectStack(s)} 
-                                        className={`list-item ${selectedStack===s ? "selected" : ""}`}
-                                    >
-                                        {s}
-                                    </div>
-                                ))}
-                            </div>
-                        </div>
-                        <div className="list">
-                            <div className="list-title">
-                                <span>Components</span>
-                                <span>{components.length}</span>
-                            </div>
-                            <div className="list-content">
-                                {components.map(c => (
-                                    <div 
-                                        key={c} 
-                                        onClick={() => selectComponent(c)} 
-                                        className={`list-item ${selectedComponent===c ? "selected" : ""}`}
-                                    >
-                                        {c}
-                                    </div>
-                                ))}
-                            </div>
-                        </div>
-                    </div>
-                    {consoleOut && (
-                        <pre className="console">
-                            {consoleOut}
-                        </pre>
-                    )}
-                </div>
-                <div className={`right-panel ${rightPanelCollapsed ? 'collapsed' : ''}`}>
-                    <div 
-                        className="toggle-panel" 
-                        onClick={() => setRightPanelCollapsed(!rightPanelCollapsed)}
-                    >
-                        <span className={`toggle-panel-icon ${rightPanelCollapsed ? 'collapsed' : ''}`}>
-                            {rightPanelCollapsed ? '›' : '‹'}
-                        </span>
-                    </div>
-                    {!rightPanelCollapsed && (
-                        <>
-                            {sections.length > 0 && (
-                                <select 
-                                    className="section-select" 
-                                    value={sectionFilter} 
-                                    onChange={e => setSectionFilter(e.target.value)}
-                                >
-                                    <option value="All">All</option>
-                                    {sections.map(s => (
-                                        <option key={s} value={s}>{s}</option>
-                                    ))}
-                                </select>
-                            )}
-                            <pre className="code-display">
-                                {displayText}
-                            </pre>
-                        </>
-                    )}
-                </div>
-            </div>
+            <Workspace key={workspaces[active].id} />
         </div>
     )
 }

--- a/desktop/frontend/src/Workspace.tsx
+++ b/desktop/frontend/src/Workspace.tsx
@@ -1,0 +1,236 @@
+import { useState } from 'react'
+import YAML from 'js-yaml'
+import {
+    PickConfigFile,
+    LoadAtmosData,
+    Describe,
+    RunTerraform,
+    AuthenticateAWS,
+} from '../wailsjs/go/main/App'
+
+interface Item { stack: string; component: string }
+
+function Workspace() {
+    const [configPath, setConfigPath] = useState('')
+    const [items, setItems] = useState<Item[]>([])
+    const [filterStack, setFilterStack] = useState('')
+    const [filterComponent, setFilterComponent] = useState('')
+    const [selectedStack, setSelectedStack] = useState<string | null>(null)
+    const [selectedComponent, setSelectedComponent] = useState<string | null>(null)
+    const [describeText, setDescribeText] = useState('')
+    const [describeObj, setDescribeObj] = useState<any>(null)
+    const [sections, setSections] = useState<string[]>([])
+    const [sectionFilter, setSectionFilter] = useState('all')
+    const [command, setCommand] = useState('plan')
+    const [consoleOut, setConsoleOut] = useState('')
+    const [rightPanelCollapsed, setRightPanelCollapsed] = useState(false)
+    const [awsProfile, setAwsProfile] = useState('')
+    const [awsMessage, setAwsMessage] = useState('')
+
+    function chooseConfig() {
+        PickConfigFile().then((path: string) => {
+            if (path) {
+                setConfigPath(path)
+                LoadAtmosData(path).then(setItems)
+            }
+        })
+    }
+
+    function authAws() {
+        if (!awsProfile) return
+        AuthenticateAWS(awsProfile).then(setAwsMessage)
+    }
+
+    function selectStack(stack: string) {
+        setSelectedStack(stack)
+        setSelectedComponent(null)
+        setDescribeText('')
+        setDescribeObj(null)
+        setSections([])
+        setSectionFilter('all')
+    }
+
+    function selectComponent(component: string) {
+        if (!selectedStack) return
+        setSelectedComponent(component)
+        Describe(selectedStack, component).then(text => {
+            setDescribeText(text)
+            try {
+                const obj = YAML.load(text)
+                if (obj && typeof obj === 'object') {
+                    setDescribeObj(obj)
+                    setSections(Object.keys(obj as any))
+                } else {
+                    setDescribeObj(null)
+                    setSections([])
+                }
+            } catch {
+                setDescribeObj(null)
+                setSections([])
+            }
+            setSectionFilter('all')
+        })
+    }
+
+    function startCommand() {
+        if (!selectedStack || !selectedComponent) return
+        RunTerraform(command, selectedStack, selectedComponent).then(setConsoleOut)
+    }
+
+    const stacks = Array.from(new Set(items.map(i => i.stack)))
+        .filter(s => filterStack === '' || s.includes(filterStack))
+        .sort()
+
+    const components = selectedStack
+        ? Array.from(new Set(items.filter(i => i.stack === selectedStack).map(i => i.component)))
+            .filter(c => filterComponent === '' || c.includes(filterComponent))
+            .sort()
+        : []
+
+    let displayText = describeText
+    if (sectionFilter !== 'all' && describeObj) {
+        const part = (describeObj as any)[sectionFilter]
+        if (part !== undefined) {
+            displayText = YAML.dump(part)
+        }
+    }
+
+    return (
+        <div className="app-container">
+            <div className="header">
+                <input
+                    className="header-input"
+                    value={configPath}
+                    readOnly
+                    placeholder="Select atmos.yaml"
+                />
+                <button
+                    className="header-button"
+                    onClick={chooseConfig}
+                >
+                    Select atmos.yaml
+                </button>
+                <input
+                    className="header-input"
+                    placeholder="AWS profile"
+                    value={awsProfile}
+                    onChange={e => setAwsProfile(e.target.value)}
+                />
+                <button
+                    className="header-button"
+                    onClick={authAws}
+                >
+                    Authenticate
+                </button>
+                {awsMessage && <span className="header-msg">{awsMessage}</span>}
+            </div>
+            <div className="main-content">
+                <div className="sidebar">
+                    <select
+                        className="sidebar-select hover:nav-gradient"
+                        value={command}
+                        onChange={e => setCommand(e.target.value)}
+                    >
+                        <option value="plan">plan</option>
+                        <option value="apply">apply</option>
+                    </select>
+                    <button
+                        className="sidebar-button"
+                        onClick={startCommand}
+                        disabled={!selectedStack || !selectedComponent}
+                    >
+                        Start
+                    </button>
+                </div>
+                <div className="content">
+                    <div className="filter-container">
+                        <input
+                            className="filter-input"
+                            placeholder="Filter stack"
+                            value={filterStack}
+                            onChange={e => setFilterStack(e.target.value)}
+                        />
+                        <input
+                            className="filter-input"
+                            placeholder="Filter component"
+                            value={filterComponent}
+                            onChange={e => setFilterComponent(e.target.value)}
+                        />
+                    </div>
+                    <div className="grid-container">
+                        <div className="list">
+                            <div className="list-title">
+                                <span>Stacks</span>
+                                <span>{stacks.length}</span>
+                            </div>
+                            <div className="list-content">
+                                {stacks.map(s => (
+                                    <div
+                                        key={s}
+                                        onClick={() => selectStack(s)}
+                                        className={`list-item ${selectedStack===s ? 'selected' : ''}`}
+                                    >
+                                        {s}
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                        <div className="list">
+                            <div className="list-title">
+                                <span>Components</span>
+                                <span>{components.length}</span>
+                            </div>
+                            <div className="list-content">
+                                {components.map(c => (
+                                    <div
+                                        key={c}
+                                        onClick={() => selectComponent(c)}
+                                        className={`list-item ${selectedComponent===c ? 'selected' : ''}`}
+                                    >
+                                        {c}
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    </div>
+                    {consoleOut && (
+                        <pre className="console">
+                            {consoleOut}
+                        </pre>
+                    )}
+                </div>
+                <div className={`right-panel ${rightPanelCollapsed ? 'collapsed' : ''}`}>
+                    <div
+                        className="toggle-panel"
+                        onClick={() => setRightPanelCollapsed(!rightPanelCollapsed)}
+                    >
+                        <span className={`toggle-panel-icon ${rightPanelCollapsed ? 'collapsed' : ''}`}>
+                            {rightPanelCollapsed ? '›' : '‹'}
+                        </span>
+                    </div>
+                    {!rightPanelCollapsed && (
+                        <>
+                            {sections.length > 0 && (
+                                <select
+                                    className="section-select"
+                                    value={sectionFilter}
+                                    onChange={e => setSectionFilter(e.target.value)}
+                                >
+                                    <option value="All">All</option>
+                                    {sections.map(s => (
+                                        <option key={s} value={s}>{s}</option>
+                                    ))}
+                                </select>
+                            )}
+                            <pre className="code-display">
+                                {displayText}
+                            </pre>
+                        </>
+                    )}
+                </div>
+            </div>
+        </div>
+    )
+}
+
+export default Workspace

--- a/desktop/frontend/src/style.css
+++ b/desktop/frontend/src/style.css
@@ -11,3 +11,29 @@ body {
   background-color: #0f172a; /* slate-900 */
   color: #f1f5f9; /* slate-100 */
 }
+
+.workspaces-container {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+}
+
+.tabs {
+  display: flex;
+  background-color: #1e293b;
+}
+
+.tab {
+  padding: 0.5rem 1rem;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+}
+
+.tab.active {
+  border-bottom-color: #38bdf8;
+}
+
+.tab.add {
+  padding: 0.5rem;
+}
+

--- a/desktop/frontend/wailsjs/go/main/App.d.ts
+++ b/desktop/frontend/wailsjs/go/main/App.d.ts
@@ -11,3 +11,5 @@ export function LoadAtmosData(arg1:string):Promise<Array<main.StackComponent>>;
 export function PickConfigFile():Promise<string>;
 
 export function RunTerraform(arg1:string,arg2:string,arg3:string):Promise<string>;
+
+export function AuthenticateAWS(arg1:string):Promise<string>;

--- a/desktop/frontend/wailsjs/go/main/App.js
+++ b/desktop/frontend/wailsjs/go/main/App.js
@@ -21,3 +21,7 @@ export function PickConfigFile() {
 export function RunTerraform(arg1, arg2, arg3) {
   return window['go']['main']['App']['RunTerraform'](arg1, arg2, arg3);
 }
+
+export function AuthenticateAWS(arg1) {
+  return window['go']['main']['App']['AuthenticateAWS'](arg1);
+}

--- a/desktop/go.mod
+++ b/desktop/go.mod
@@ -3,6 +3,8 @@ module github.com/cloudposse/atmos/desktop
 go 1.24.4
 
 require (
+	github.com/aws/aws-sdk-go-v2/config v1.29.17
+	github.com/aws/aws-sdk-go-v2/service/sts v1.34.0
 	github.com/cloudposse/atmos v1.181.0
 	github.com/wailsapp/wails/v2 v2.10.1
 	gopkg.in/yaml.v3 v3.0.1
@@ -53,7 +55,6 @@ require (
 	github.com/aws/aws-sdk-go v1.44.206 // indirect
 	github.com/aws/aws-sdk-go-v2 v1.36.5 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.4.1 // indirect
-	github.com/aws/aws-sdk-go-v2/config v1.29.17 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.70 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.32 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.11.14 // indirect
@@ -69,7 +70,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssm v1.59.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.25.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.3 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.34.0 // indirect
 	github.com/aws/smithy-go v1.22.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/aymerick/douceur v0.2.0 // indirect


### PR DESCRIPTION
## Summary
- create workspace component to hold UI state
- add tab-based workspace switching in the frontend
- allow authenticating AWS profiles per workspace
- expose `AuthenticateAWS` method in the desktop backend
- style tab bar

## Testing
- `make lint` *(fails: can't load config)*
- `make testacc-cover` *(interrupted)*
- `go test ./...` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_b_68714437ef9c832ba3f80fafa2e42c24